### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BNF parser and validator
 
-I'm not a 100% sure what is project is/will be. Currently just implementing some dragon book algorithms. May become a parser generator.
+I'm not a 100% sure what this project is/will be. Currently just implementing some dragon book algorithms. May become a parser generator.
 
 ## Usage
 


### PR DESCRIPTION
# Problem
The current README is grammatically incorrect and causes confusion for potential contributors.

# Solution
Changed `is` to `this`

# Checklist
- [x] Tests all passing
- [x] Lint passing